### PR TITLE
Fix pond sorting by name

### DIFF
--- a/PondMaps/dfw-pond-maps-table.html
+++ b/PondMaps/dfw-pond-maps-table.html
@@ -17,21 +17,31 @@
      google.charts.setOnLoadCallback(drawTable);
 	  
 	function drawTable() {
-		var queryString = encodeURIComponent("SELECT 'col3', 'col4', 'col9'");
-		var pondQuery = new google.visualization.Query('https://www.google.com/fusiontables/gvizdata?tq=' + queryString + 'FROM 1L-zu7mgX9_sFgnP2QWf3drQ1MRUXgAEIiLteHabn');
+		var queryString = encodeURIComponent("SELECT 'col1', 'col3', 'col4', 'col9'");
+		// Make sure it's properly ordered to start with (A-1 Site should be first, not Aldrich Lake)
+		var orderedBy = encodeURIComponent("ORDER BY 'col1'");
+		var pondQuery = new google.visualization.Query('https://www.google.com/fusiontables/gvizdata?tq=' + queryString + ' FROM 1L-zu7mgX9_sFgnP2QWf3drQ1MRUXgAEIiLteHabn ' + orderedBy);
 		
 		pondQuery.send(handleQueryResponse);
 	} 
  
     function handleQueryResponse(response) {
-
         if (response.isError()) {
             alert('Error in query: ' + response.getMessage());response.getDetailedMessage();
             return;
         }
 
 		var data = response.getDataTable();
-		
+
+        // Modify table data so it is correctly sorted by pond name AND clickable
+        var numRows = data.getNumberOfRows();
+        for (var i=0; i<numRows; i++) {
+            var mapLinkWithName = data.getFormattedValue(i, 1);
+            var rawName=data.getValue(i, 0);
+            data.setValue(i, 1, rawName); // cell value is what is sorted on, this should be raw name of the pond, not a hyperlink string
+            data.setFormattedValue(i, 1, mapLinkWithName); // this is what our visualization will display
+        }
+
 		var dashboard = new google.visualization.Dashboard(document.getElementById('dashboard_div'));
 		
 		var myTable = new google.visualization.ChartWrapper({
@@ -43,7 +53,8 @@
 				page: 'enable',
 				pageSize: 25,
 				allowHtml: true
-			}
+			},
+            view: {'columns': [1,2,3]} // Hide the raw name column from view
 		});
 		
 		var filterTown= new google.visualization.ControlWrapper({
@@ -62,7 +73,7 @@
 			 matchType: 'any'
         }
 		});
-		dashboard.bind([filterPond],[filterTown])
+		dashboard.bind([filterPond],[filterTown]);
 		dashboard.bind([filterTown], [myTable]);
 		dashboard.draw(data);
 		}


### PR DESCRIPTION
Hi all, noticed this thread on IceShanty.com where it was mentioned that sorting was broken for Pond Maps.

I'm a web developer so I decided to take a look at the page. When I saw it was hosted at github.io I found this repo. Was a relatively straightforward fix. Existing implementation is causing the table to sort the full html link, as you probably already know. Stuff like:

```
<a href="https://www.mass.gov/files/documents/2016/08/xk/dfwaldr.pdf" target="_blank">Aldrich Lake</a>
```
Instead you want to sort on just the name:

```
Aldrich Lake
```
That's what's breaking the sorting. 

My change loops through the returned data first and explicitly sets a value for sorting and a value for display. Thanks for open sourcing this!